### PR TITLE
Add sync version of wgBumpSockets

### DIFF
--- a/src/api-apple.go
+++ b/src/api-apple.go
@@ -193,6 +193,24 @@ func wgBumpSockets(tunnelHandle int32) {
 	}()
 }
 
+//export wgBumpSocketsAndWait
+func wgBumpSocketsAndWait(tunnelHandle int32) {
+	dev, ok := tunnelHandles[tunnelHandle]
+	if !ok {
+		return
+	}
+	for i := 0; i < 10; i++ {
+		err := dev.BindUpdate()
+		if err == nil {
+			dev.SendKeepalivesToPeersWithCurrentKeypair()
+			return
+		}
+		dev.Errorf("Unable to update bind, try %d: %v", i+1, err)
+		time.Sleep(time.Second / 2)
+	}
+	dev.Errorf("Gave up trying to update bind; tunnel is likely dysfunctional")
+}
+
 //export wgDisableSomeRoamingForBrokenMobileSemantics
 func wgDisableSomeRoamingForBrokenMobileSemantics(tunnelHandle int32) {
 	dev, ok := tunnelHandles[tunnelHandle]

--- a/src/wg_go.h
+++ b/src/wg_go.h
@@ -17,6 +17,7 @@ extern void wgTurnOff(int handle);
 extern int64_t wgSetConfig(int handle, const char *settings);
 extern char *wgGetConfig(int handle);
 extern void wgBumpSockets(int handle);
+extern void wgBumpSocketsAndWait(int handle);
 extern void wgDisableSomeRoamingForBrokenMobileSemantics(int handle);
 extern const char *wgVersion();
 


### PR DESCRIPTION
The result of the bump might be relevant, e.g., to reinspect the active sockets.